### PR TITLE
Server

### DIFF
--- a/source/irc-server/include/server.hpp
+++ b/source/irc-server/include/server.hpp
@@ -23,23 +23,4 @@ namespace Server
     void listen(int queueSize);
 };
 
-
-// class Server
-// {
-//     public:
-//     Server(const char* _port);
-//     void listen(int queueSize);
-//     ~Server();
-//     private:
-//     std::string port;
-//     int listenSocket;
-//     int testFD;
-//     void setup();
-// };
-
-
-
-
-
-
 #endif

--- a/source/irc-server/include/server.hpp
+++ b/source/irc-server/include/server.hpp
@@ -1,15 +1,45 @@
 #ifndef SERVER_HPP
 #include <string>
 
-class Server
+
+typedef class File_descriptor
 {
-    public:
-    Server(const char* _port);
     private:
-    std::string port;
-    int listenSocket;
-    void setup();
+    int fd;
+    public:
+    File_descriptor();
+    File_descriptor(int _fd);
+    File_descriptor& operator=(File_descriptor&& other) noexcept;
+    ~File_descriptor();
+    operator int() const {return fd;}
+
+
+} fd_type;
+
+
+namespace Server
+{
+    void Server(const char* _port);
+    void listen(int queueSize);
 };
+
+
+// class Server
+// {
+//     public:
+//     Server(const char* _port);
+//     void listen(int queueSize);
+//     ~Server();
+//     private:
+//     std::string port;
+//     int listenSocket;
+//     int testFD;
+//     void setup();
+// };
+
+
+
+
 
 
 #endif

--- a/source/irc-server/include/server.hpp
+++ b/source/irc-server/include/server.hpp
@@ -1,7 +1,4 @@
 #ifndef SERVER_HPP
-#include <string>
-
-
 typedef class File_descriptor
 {
     private:

--- a/source/irc-server/main.cpp
+++ b/source/irc-server/main.cpp
@@ -24,8 +24,8 @@ int main(int argc, char* args[])
 
 		return 1;
 	}
-
-	Server server("4000");
+	Server::Server("4000");
+	Server::listen(10);
 
 	return 0;
 }

--- a/source/irc-server/server.cpp
+++ b/source/irc-server/server.cpp
@@ -41,7 +41,7 @@
 
 
 
-File_descriptor::File_descriptor(){}
+File_descriptor::File_descriptor(): fd(-1){}
 File_descriptor::File_descriptor(int _fd): fd(_fd){}
 File_descriptor::~File_descriptor() 
 {
@@ -51,7 +51,6 @@ File_descriptor::~File_descriptor()
 
 File_descriptor& File_descriptor::operator=(File_descriptor&& other) noexcept
 {
-    fd = -1;
     std::swap(other.fd, fd);
     return *this;
 }

--- a/source/irc-server/server.cpp
+++ b/source/irc-server/server.cpp
@@ -129,6 +129,7 @@ namespace
             ERROR("failed to bind");
     }
 }
+    /* current implementation for testing only */
     void listen(int queueSize)
     {
         int s = ::listen(listenSocket, queueSize);

--- a/source/irc-server/server.cpp
+++ b/source/irc-server/server.cpp
@@ -62,7 +62,7 @@ namespace Server
     namespace
     {
         std::string port;
-        static fd_type listenSocket;
+        fd_type listenSocket;
         fd_type testFD;
         void setup();
     };

--- a/source/irc-server/server.cpp
+++ b/source/irc-server/server.cpp
@@ -40,13 +40,6 @@
 	}
 
 
-#ifdef KQUEUE
-void event_handler()
-{
-
-}
-#endif
-
 
 File_descriptor::File_descriptor(){}
 File_descriptor::File_descriptor(int _fd): fd(_fd){}
@@ -55,6 +48,7 @@ File_descriptor::~File_descriptor()
     if (fd != -1) 
         close (fd);
 }
+
 File_descriptor& File_descriptor::operator=(File_descriptor&& other) noexcept
 {
     fd = -1;


### PR DESCRIPTION
Added a file descriptor class that will automatically close the file descriptor it's holding.
Only the move assignment operator is used. Might need to implement the rule of 5 but i can't see why you would wanna copy the fd when it's going to close if you do. Maybe I should declare those delete? I'll probably at least add the move constructor. 